### PR TITLE
Create ParseLines method for parse a string

### DIFF
--- a/Azihub.Utilities.Base/Tools/DotEnv.cs
+++ b/Azihub.Utilities.Base/Tools/DotEnv.cs
@@ -20,7 +20,13 @@ namespace Azihub.Utilities.Base.Tools
             IDictionary<string, string> variable = DotEnvFile.LoadFile(filePath, true);
             DotEnvFile.InjectIntoEnvironment(EnvironmentVariableTarget.Process, variable);
         }
-
+        
+        public static void ParsLines(IEnumerable<string> lines)
+        {
+            IDictionary<string, string> variables = DotEnvFile.ParseLines(lines, true);
+            DotEnvFile.InjectIntoEnvironment(EnvironmentVariableTarget.Process, variables);
+        }
+        
         public static T Load<T>() where T : new()
         {
 

--- a/Azihub.Utilities.Tests/DotEnvTests/DotEnvTests.cs
+++ b/Azihub.Utilities.Tests/DotEnvTests/DotEnvTests.cs
@@ -2,6 +2,7 @@
 using Azihub.Utilities.Base.Tools.Annotations;
 using Azihub.Utilities.Tests.DotEnvTests.Samples;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Xunit;
 using Azihub.Utilities.Base.Extensions.String;
@@ -34,6 +35,19 @@ namespace Azihub.Utilities.Tests.DotEnvTests
         {
             // Act
             DotEnv.Load(TempEnvFileFixcture.EnvFilePath);
+            string testVar1 = Environment.GetEnvironmentVariable(nameof(TestEnvSettings.TestVar1).PascalToSnakeCase());
+            string testVar2 = Environment.GetEnvironmentVariable(typeof(TestEnvSettings).GetEnvName(nameof(TestEnvSettings.Var2)) );
+
+            // Assert
+            Assert.Equal(TempEnvFileFixcture.VarValue1, testVar1);
+            Assert.Equal(TempEnvFileFixcture.VarValue2, testVar2);
+        }
+        
+        [Fact]
+        public void ParsLinesDotEnvTests()
+        {
+            // Act
+            DotEnv.ParsLines(TempEnvFileFixcture.testEnvs.Split("\n"));
             string testVar1 = Environment.GetEnvironmentVariable(nameof(TestEnvSettings.TestVar1).PascalToSnakeCase());
             string testVar2 = Environment.GetEnvironmentVariable(typeof(TestEnvSettings).GetEnvName(nameof(TestEnvSettings.Var2)) );
 
@@ -76,11 +90,12 @@ namespace Azihub.Utilities.Tests.DotEnvTests
         public string VarValue1 = "TEST_VALUE1";
         public string VarName2 = "TEST_VAR2";
         public string VarValue2 = "TEST_VALUE2";
+        public string testEnvs;
         public TempEnvFileFixcture()
         {
-            string testEnvs = "# COMMENT TEST\n" +
-                            $"{VarName1}={VarValue1}\n" +
-                            $"{VarName2}={VarValue2}\n";
+            testEnvs = "# COMMENT TEST\n" +
+                       $"{VarName1}={VarValue1}\n" +
+                       $"{VarName2}={VarValue2}\n";
 
             EnvFilePath = Path.GetTempPath() + ".env";
             File.WriteAllText(EnvFilePath, testEnvs);


### PR DESCRIPTION
In Blazor webassembly , we can't get file path , we can just read content of file, so we need method that parse string that come from reading file.
I added ParsLines method for solve this problem.

```
 [Fact]
        public void ParsLinesDotEnvTests()
        {
            // Act
            DotEnv.ParsLines(TempEnvFileFixcture.testEnvs.Split("\n"));
            string testVar1 = Environment.GetEnvironmentVariable(nameof(TestEnvSettings.TestVar1).PascalToSnakeCase());
            string testVar2 = Environment.GetEnvironmentVariable(typeof(TestEnvSettings).GetEnvName(nameof(TestEnvSettings.Var2)) );

            // Assert
            Assert.Equal(TempEnvFileFixcture.VarValue1, testVar1);
            Assert.Equal(TempEnvFileFixcture.VarValue2, testVar2);
        }
```

```
 public class TempEnvFileFixcture : IDisposable
    {
        public string EnvFilePath { get; set; }
        public string VarName1 = "TEST_VAR1";
        public string VarValue1 = "TEST_VALUE1";
        public string VarName2 = "TEST_VAR2";
        public string VarValue2 = "TEST_VALUE2";
        public string testEnvs;
        public TempEnvFileFixcture()
        {
            testEnvs = "# COMMENT TEST\n" +
                       $"{VarName1}={VarValue1}\n" +
                       $"{VarName2}={VarValue2}\n";

            EnvFilePath = Path.GetTempPath() + ".env";
            File.WriteAllText(EnvFilePath, testEnvs);
        }
```